### PR TITLE
Update for Sequelize 3.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,11 +9,11 @@ SequelizeAdapter.prototype.build = function(Model, props) {
 };
 
 SequelizeAdapter.prototype.save = function(doc, Model, cb) {
-  doc.save().complete(cb);
+  doc.save().nodeify(cb);
 };
 
 SequelizeAdapter.prototype.destroy = function(doc, Model, cb) {
-  doc.destroy().complete(cb);
+  doc.destroy().nodeify(cb);
 };
 
 var adapter = new SequelizeAdapter();

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "config-node": "^1.2.2",
     "factory-girl": "^1.1.2",
     "mocha": "^2.0.1",
-    "sequelize": "^2.0.0-rc3",
+    "sequelize": "^3.0.0",
     "sqlite3": "^3.0.4"
   }
 }

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -24,7 +24,7 @@ describe('Bookshelf adapter', function() {
     before(function() {
       return sequelize.sync()
         .then(function() {
-          return Model.destroy();
+          return Model.destroy({where: {}});
         });
     });
   }


### PR DESCRIPTION
Sequelize appears to have removed the `.complete` method as of 3.0.0. I just replaced it with `.nodeify` since Sequelize uses Bluebird.